### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Microchip_25AA02E48/keywords.txt
+++ b/Microchip_25AA02E48/keywords.txt
@@ -6,17 +6,17 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Microchip_25AA02E48   KEYWORD1
+Microchip_25AA02E48	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-readStatus     KEYWORD2
-readRegister   KEYWORD2
-getEUI48       KEYWORD2
-getEUI64       KEYWORD2
-writeRegister  KEYWORD2
+readStatus	KEYWORD2
+readRegister	KEYWORD2
+getEUI48	KEYWORD2
+getEUI64	KEYWORD2
+writeRegister	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords